### PR TITLE
Add dummy argument when opening a directory

### DIFF
--- a/expose-filemanager.py
+++ b/expose-filemanager.py
@@ -19,6 +19,8 @@ class XfceFileManager(object):
         for item in items:
             path = dirname(item)
             filename = basename(item)
+            if filename == '':
+                filename = '.'
             self.interface.DisplayFolderAndSelect(path, filename, '', '')
 
     def ShowItemProperties(self, items):


### PR DESCRIPTION
Eclipse always sends the SystemExplorer argument via SendItems,
so opening a directory ends up with a valid path but without
filename. Add fake argument "." in that case.

Fixes: #1 ('Still getting return code 1 from eclipse')
